### PR TITLE
Github docker-compose no longer supported.

### DIFF
--- a/aws-lambda/pom.xml
+++ b/aws-lambda/pom.xml
@@ -94,11 +94,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
             <scope>test</scope>
         </dependency>

--- a/aws-utilities/pom.xml
+++ b/aws-utilities/pom.xml
@@ -50,11 +50,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.awspring.cloud</groupId>
             <artifactId>spring-cloud-aws-sqs</artifactId>
             <scope>provided</scope>
@@ -100,11 +95,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jar-development/pom.xml
+++ b/jar-development/pom.xml
@@ -72,10 +72,6 @@
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/java-development/pom.xml
+++ b/java-development/pom.xml
@@ -49,8 +49,9 @@
         <coverage.exclude.pattern.4/>
         <coverage.exclude.pattern.5/>
 
-        <!-- Docker port to wait for -->
-        <docker.compose.port>4566</docker.compose.port>
+        <!-- docker test configuration defaults -->
+        <docker.test.compose.dir>${project.basedir}/src/test/docker</docker.test.compose.dir>
+        <docker.test.compose.file>${docker.test.compose.dir}/docker-compose.yml</docker.test.compose.file>
 
         <!-- Compiler configuration assuming JDK 11 or higher -->
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -68,7 +69,6 @@
         <coverage.exclude.build.pattern.4/>
         <coverage.exclude.build.pattern.5/>
 
-        <test.compose.location>${project.basedir}/src/test/docker/docker-compose.yml</test.compose.location>
         <lombok.outputDirectory>${project.build.directory}/generated-sources/delombok</lombok.outputDirectory>
 
         <!-- This can be disabled by profile - suggest fast-build -->
@@ -114,79 +114,64 @@
                             <configuration>
                                 <exportAntProperties>true</exportAntProperties>
                                 <target>
-                                    <condition property="docker.compose.skip" else="false">
+                                    <condition property="docker.test.compose.skip" else="false">
                                         <or>
                                             <equals arg1="${lime.fast-build}" arg2="true"/>
                                             <not>
-                                                <available file="${test.compose.location}"/>
+                                                <available file="${docker.test.compose.file}"/>
                                             </not>
                                         </or>
                                     </condition>
                                     <!--suppress UnresolvedMavenProperty -->
-                                    <echo level="info" message="docker.compose.skip is ${docker.compose.skip}"/>
-
-                                    <!-- Remove this later if we need to replace docker plugin -->
+                                    <echo level="info" message="docker.test.compose.skip is ${docker.test.compose.skip}"/>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>docker-up</id>
+                            <!--
+                             NOTE THAT LIFECYCLE CHECKS IN DOCKER COMPOSE FILES ARE REQUIRED
+                             AS NO WAIT AFTER STARTUP BEFORE TESTING BEGINS.
+                             -->
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <phase>pre-integration-test</phase>
+                            <configuration>
+                                <!--suppress MavenModelInspection -->
+                                <skip>${docker.test.compose.skip}</skip>
+                                <target>
                                     <exec executable="docker"
+                                          dir="${docker.test.compose.dir}"
                                           failifexecutionfails="true"
                                           failonerror="true">
-                                        <arg line="compose --help"/>
+                                        <arg value="compose"/>
+                                        <arg value="up"/>
+                                        <arg value="--detach"/>
                                     </exec>
                                 </target>
                             </configuration>
                         </execution>
                         <execution>
-                            <id>wait-for-docker</id>
-                            <phase>integration-test</phase>
+                            <id>docker-down</id>
                             <goals>
                                 <goal>run</goal>
                             </goals>
-                            <configuration>
-                                <target xmlns:ac="antlib:net.sf.antcontrib">
-                                    <ac:if>
-                                        <!--suppress UnresolvedMavenProperty -->
-                                        <equals arg1="${docker.compose.skip}" arg2="false"/>
-                                        <then>
-                                            <echo level="info"
-                                                  message="Waiting for Docker on port ${docker.compose.port}"/>
-                                            <waitfor maxWait="2" maxWaitUnit="minute">
-                                                <http url="http://localhost:${docker.compose.port}"/>
-                                            </waitfor>
-                                        </then>
-                                    </ac:if>
-                                </target>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.dkanejs.maven.plugins</groupId>
-                    <artifactId>docker-compose-maven-plugin</artifactId>
-                    <configuration>
-                        <composeFile>${project.basedir}/src/test/docker/docker-compose.yml</composeFile>
-                        <!-- Set by antrun task execution -->
-                        <!--suppress UnresolvedMavenProperty, MavenModelInspection -->
-                        <skip>${docker.compose.skip}</skip>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>docker-up</id>
-                            <goals>
-                                <goal>up</goal>
-                            </goals>
-                            <phase>pre-integration-test</phase>
-                            <configuration>
-                                <detachedMode>true</detachedMode>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>docker-down</id>
-                            <goals>
-                                <goal>down</goal>
-                            </goals>
                             <phase>post-integration-test</phase>
                             <configuration>
-                                <removeOrphans>true</removeOrphans>
-                                <removeVolumes>true</removeVolumes>
+                                <!--suppress MavenModelInspection -->
+                                <skip>${docker.test.compose.skip}</skip>
+                                <target>
+                                    <exec executable="docker"
+                                          dir="${docker.test.compose.dir}"
+                                          failifexecutionfails="true"
+                                          failonerror="true">
+                                        <arg value="compose"/>
+                                        <arg value="down"/>
+                                        <arg value="--remove-orphans"/>
+                                        <arg value="--volumes"/>
+                                    </exec>
+                                </target>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -118,14 +118,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>com.dkanejs.maven.plugins</groupId>
-                    <artifactId>docker-compose-maven-plugin</artifactId>
-                    <version>4.0.0</version>
-                    <configuration>
-                        <composeFile>${project.basedir}/src/test/docker/docker-compose.yml</composeFile>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>3.1.0</version>

--- a/spring-boot-development/pom.xml
+++ b/spring-boot-development/pom.xml
@@ -71,10 +71,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>

--- a/spring-boot-development/src/test/docker/docker-compose.yml
+++ b/spring-boot-development/src/test/docker/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.4'
 services:
   localstack:
-    image: localstack/localstack:3.1
+    image: localstack/localstack:stable
     ports:
       - "4566:4566"
     environment:

--- a/test-utilities/pom.xml
+++ b/test-utilities/pom.xml
@@ -151,11 +151,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/test-utilities/src/test/docker/docker-compose.yml
+++ b/test-utilities/src/test/docker/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.4'
 services:
   localstack:
-    image: localstack/localstack:3.1
+    image: localstack/localstack:stable
     ports:
       - "4566:4566"
     environment:


### PR DESCRIPTION
Replaced docker compose plugin as the latest gitlab runners do not support docker-compose, but the now standard docker compose commands.  Updated localstack references to stable.  Removed version from docker compose files.  Cleaned up dependency warnings.  Removed docker waitFor to rely on docker-compose.yml health checks.