### PR TITLE
Feature/127 enable incremental builder https

### DIFF
--- a/.github/actions/maven-incremental-build/action.yml
+++ b/.github/actions/maven-incremental-build/action.yml
@@ -40,7 +40,7 @@ runs:
           --file pom.xml \
           -Dbuild.number=${{github.run_number}} \
           -Dgpg.keyname='Lime Mojito Pty Ltd' \
-          -Dgib.referenceBranch=refs/heads/${DEFAULT_BRANCH} \
+          -Dgit.defaultBranch=${DEFAULT_BRANCH} \
           ${{ inputs.extra-mvn-options }} \
           -Pincremental \
           clean install 

--- a/.github/actions/maven-incremental-build/action.yml
+++ b/.github/actions/maven-incremental-build/action.yml
@@ -42,6 +42,7 @@ runs:
           -Dgpg.keyname='Lime Mojito Pty Ltd' \
           -Dgib.referenceBranch=refs/heads/${DEFAULT_BRANCH} \
           ${{ inputs.extra-mvn-options }} \
+          -Pincremental \
           clean install 
 
     - name: Upload Reports

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ target
 cdk.out
 # Old Junie configuration
 .junie/
-!AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,6 @@ atlassian-ide-plugin.xml
 .idea
 target
 cdk.out
-# Junie configuration
+# Old Junie configuration
 .junie/
-!.junie/config.json
-!.junie/skills/
-!.junie/agents/
-!.junie/commands/
-!.junie/mcp/
-!.junie/models/
 !AGENTS.md

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,8 @@
                         <extensions>true</extensions>
                         <configuration>
                             <!-- Default branch name is passed in from GitHub action -->
-                           <referenceBranch>refs/heads/${git.defaultBranch}</referenceBranch>
+                            <referenceBranch>refs/remote/origin/${git.defaultBranch}</referenceBranch>
+                            <fetchReferenceBranch>true</fetchReferenceBranch>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <!-- Default branch name is passed in from GitHub action -->
-                            <referenceBranch>remotes/origin/${git.defaultBranch}</referenceBranch>
+                            <referenceBranch>refs/remotes/origin/${git.defaultBranch}</referenceBranch>
                             <fetchReferenceBranch>true</fetchReferenceBranch>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -441,10 +441,11 @@
         </profile>
 
         <profile>
-            <id>ci</id>
-            <properties>
-                <ci>true</ci>
-            </properties>
+            <id>incremental</id>
+            <!--
+              Note this profile may interfere with the Multi Module Maven Release plugin.  It is not enabled by default
+              The disable-gib profile automatically disables this in Intellij.
+             -->
             <build>
                 <plugins>
                     <plugin>
@@ -452,7 +453,7 @@
                         <artifactId>gitflow-incremental-builder</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <!-- Default branch name is passed in from github action -->
+                            <!-- Default branch name is passed in from GitHub action -->
                             <!-- <referenceBranch>refs/heads/master</referenceBranch>-->
                         </configuration>
                     </plugin>
@@ -464,7 +465,7 @@
             <id>disable-gib-in-intellij</id>
             <activation>
                 <property>
-                    <!-- This property is natively exported by IntelliJ during imports/builds -->
+                    <!-- IntelliJ natively exports this property during imports/builds -->
                     <name>idea.version</name>
                 </property>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
         <github.url>https://github.com/${git.project.slug}</github.url>
         <git.url>git@github.com:${git.project.slug}.git</git.url>
+        <git.defaultBranch>master</git.defaultBranch>
         <lime.scm.url>scm:git:${git.url}</lime.scm.url>
         <lime.website.url>https://limemojito.com</lime.website.url>
         <central.base.url>https://central.sonatype.com</central.base.url>
@@ -454,7 +455,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <!-- Default branch name is passed in from GitHub action -->
-                            <!-- <referenceBranch>refs/heads/master</referenceBranch>-->
+                           <referenceBranch>refs/heads/${git.defaultBranch}</referenceBranch>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <!-- Default branch name is passed in from GitHub action -->
-                            <referenceBranch>refs/remote/origin/${git.defaultBranch}</referenceBranch>
+                            <referenceBranch>remotes/origin/${git.defaultBranch}</referenceBranch>
                             <fetchReferenceBranch>true</fetchReferenceBranch>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <!-- Useful things made from the development archetypes -->
         <module>applications</module>
 
-        <!-- Publish a BOM so it is easy to manage dependencies -->
+        <!-- Publish a BOM so that it is easy to manage dependencies -->
         <module>lime-oss-maven-standards-bom</module>
 
         <!-- Test the dev framework -->


### PR DESCRIPTION
Update incremental builder to use a passthrough maven property with the remote default branch name.  Remote default branch is always fetched.